### PR TITLE
Configure structured logging using structlog

### DIFF
--- a/servicelayer/logs.py
+++ b/servicelayer/logs.py
@@ -43,10 +43,10 @@ def configure_logging(level=logging.INFO):
     )
 
     # handler for low level logs that should be sent to STDOUT
-    info_handler = logging.StreamHandler(sys.stdout)
-    info_handler.setLevel(level)
-    info_handler.addFilter(_MaxLevelFilter(logging.WARNING))
-    info_handler.setFormatter(formatter)
+    out_handler = logging.StreamHandler(sys.stdout)
+    out_handler.setLevel(level)
+    out_handler.addFilter(_MaxLevelFilter(logging.WARNING))
+    out_handler.setFormatter(formatter)
     # handler for high level logs that should be sent to STDERR
     error_handler = logging.StreamHandler(sys.stderr)
     error_handler.setLevel(logging.ERROR)
@@ -56,7 +56,7 @@ def configure_logging(level=logging.INFO):
     root_logger.setLevel(logging.DEBUG)
     # check to prevent adding duplicate handlers
     if not root_logger.handlers:
-        root_logger.addHandler(info_handler)
+        root_logger.addHandler(out_handler)
         root_logger.addHandler(error_handler)
 
 

--- a/servicelayer/logs.py
+++ b/servicelayer/logs.py
@@ -1,12 +1,75 @@
 import logging
+import sys
+
+import structlog
+from structlog.contextvars import merge_contextvars
 
 from servicelayer import settings
 
+LOG_FORMAT_TEXT = "TEXT"
+LOG_FORMAT_JSON = "JSON"
 
-def configure_logging():
-    """setup logging configuration and return current log level"""
-    level = getattr(logging, settings.LOGGING_LEVEL, None)
-    if level is None:
-        raise ValueError("Invalid log level: %s" % settings.LOGGING_LEVEL)
-    logging.basicConfig(level=level, format=settings.LOGGING_FORMAT)
-    return level
+
+def configure_logging(level=logging.INFO):
+    """Configure log levels and structured logging"""
+    common_processors = [
+        structlog.stdlib.add_log_level,
+        structlog.stdlib.add_logger_name,
+        structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M:%S.%f"),
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.processors.format_exc_info,
+        structlog.processors.UnicodeDecoder(),
+    ]
+    if settings.LOG_FORMAT == LOG_FORMAT_TEXT:
+        processors = common_processors
+        formatter = structlog.stdlib.ProcessorFormatter(
+            foreign_pre_chain=processors, processor=structlog.dev.ConsoleRenderer(),
+        )
+    else:
+        processors = common_processors + [
+            merge_contextvars,
+            format_stackdriver,
+        ]
+        formatter = structlog.stdlib.ProcessorFormatter(
+            foreign_pre_chain=processors, processor=structlog.processors.JSONRenderer(),
+        )
+
+    # configuration for structlog based loggers
+    structlog.configure(
+        processors=processors
+        + [structlog.stdlib.ProcessorFormatter.wrap_for_formatter,],
+        logger_factory=structlog.stdlib.LoggerFactory(),
+    )
+
+    # handler for low level logs that should be sent to STDOUT
+    info_handler = logging.StreamHandler(sys.stdout)
+    info_handler.setLevel(level)
+    info_handler.addFilter(_MaxLevelFilter(logging.WARNING))
+    info_handler.setFormatter(formatter)
+    # handler for high level logs that should be sent to STDERR
+    error_handler = logging.StreamHandler(sys.stderr)
+    error_handler.setLevel(logging.ERROR)
+    error_handler.setFormatter(formatter)
+
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.DEBUG)
+    # check to prevent adding duplicate handlers
+    if not root_logger.handlers:
+        root_logger.addHandler(info_handler)
+        root_logger.addHandler(error_handler)
+
+
+def format_stackdriver(_, __, ed):
+    """Stackdriver uses `message` and `severity` keys to display logs"""
+    ed["message"] = ed.pop("event")
+    ed["severity"] = ed.pop("level", "info").upper()
+    return ed
+
+
+class _MaxLevelFilter(object):
+    def __init__(self, highest_log_level):
+        self._highest_log_level = highest_log_level
+
+    def filter(self, log_record):
+        return log_record.levelno <= self._highest_log_level

--- a/servicelayer/settings.py
+++ b/servicelayer/settings.py
@@ -31,6 +31,4 @@ PUBLICATION_BUCKET = env.get("PUBLICATION_BUCKET")
 PUBLICATION_PATH = env.get("PUBLICATION_PATH")
 
 # Logging
-LOGGING_LEVEL = env.get("LOGGING_LEVEL", "DEBUG").upper()
-LOGGING_FORMAT = "%(levelname)s:%(name)s:%(message)s"
-LOGGING_FORMAT = env.get("LOGGING_FORMAT", LOGGING_FORMAT)
+LOG_FORMAT = env.get("LOG_FORMAT", "TEXT")  # options are: TEXT or JSON


### PR DESCRIPTION
Structured logging configuration have to be used in all our workloads including Aleph, Memorious and FTM-ETL jobs so that log entries are parsed correctly by Stackdriver and error reporting works properly.