### PR TITLE
Enable IAM role-based auth between EC2 and S3

### DIFF
--- a/servicelayer/archive/s3.py
+++ b/servicelayer/archive/s3.py
@@ -16,9 +16,10 @@ class S3Archive(VirtualArchive):
 
     def __init__(self, bucket=None, publication_bucket=None):
         super(S3Archive, self).__init__(bucket)
+        # If key id and secret key env variables are present, use them to instantiate the s3 client.
+        # Otherwise assume we're running on an EC2 instance with a role that has
+        # the appropriate access to the archive bucket.
         key_args = {}
-        # If key id and secret key are present, use them to instantiate an s3 client.
-        # Otherwise assume we're running on EC2 with a role that has access to the archive bucket.
         if settings.AWS_KEY_ID and settings.AWS_SECRET_KEY:
             key_args["key_id"] = settings.AWS_KEY_ID
             key_args["secret_key"] = settings.AWS_SECRET_KEY

--- a/servicelayer/archive/s3.py
+++ b/servicelayer/archive/s3.py
@@ -16,14 +16,18 @@ class S3Archive(VirtualArchive):
 
     def __init__(self, bucket=None, publication_bucket=None):
         super(S3Archive, self).__init__(bucket)
-        key_id = settings.AWS_KEY_ID
-        secret_key = settings.AWS_SECRET_KEY
+        key_args = {}
+        # If key id and secret key are present, use them to instantiate an s3 client.
+        # Otherwise assume we're running on EC2 with a role that has access to the archive bucket.
+        if settings.AWS_KEY_ID and settings.AWS_SECRET_KEY:
+            key_args["key_id"] = settings.AWS_KEY_ID
+            key_args["secret_key"] = settings.AWS_SECRET_KEY
+
         self.client = boto3.client(
             "s3",
             endpoint_url=settings.ARCHIVE_ENDPOINT_URL,
             region_name=settings.AWS_REGION,
-            aws_access_key_id=key_id,
-            aws_secret_access_key=secret_key,
+            **key_args
         )
         # config=Config(signature_version='s3v4'))
         self.bucket = bucket


### PR DESCRIPTION
related to https://github.com/alephdata/aleph/issues/3185

## What 
Enables IAM role-based auth by allowing environment variables `AWS_KEY_ID` and `AWS_SECRET_KEY` to be left unpopulated. When neither is populated, `key_id` and `secret_key` won't be passed to the s3 client constructor which will instead [look for credentials in instance metadata](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html#id1).

## Why
As described in the issue above, role based auth has a few advantages over user-based auth: 
- better security: admins wouldn't need to store, and manage, and rotate secret keys, risking their being compromised.
- more specific access control: only the EC2 instance running Aleph will have access to the archive S3 bucket, rather than any client with the access key

Note: when Aleph is running on docker on an EC2 instance, it might be necessary to increase its launch template's [HttpPutResponseHopLimit](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_InstanceMetadataOptionsRequest.html) from the default of 1 to 2 so that instance metadata can be fetched. 