### PR TITLE
Make servicelayer cross-compatible with SQLAlchemy 1.4 and 2+

### DIFF
--- a/servicelayer/tags.py
+++ b/servicelayer/tags.py
@@ -18,7 +18,7 @@ class Tags(object):
 
     def __init__(self, name, uri=settings.TAGS_DATABASE_URI, **config):
         self.name = name
-        self.engine = create_engine(uri, **config)
+        self.engine = create_engine(uri, future=True, **config)
         self.is_postgres = self.engine.dialect.name == "postgresql"
         self.table = Table(
             name,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "banal >= 1.0.6, < 2.0.0",
         "normality >= 2.4.0, < 3.0.0",
         "fakeredis >=2.11.2, < 3.0.0",
-        "sqlalchemy >= 1.3.2, < 3.0.0",
+        "sqlalchemy >= 1.4.49, < 3.0.0",
         "structlog >= 20.2.0, < 24.0.0",
         "colorama >= 0.4.4, < 1.0.0",
         "pika >= 1.3.1, < 2.0.0",

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         "banal >= 1.0.6, < 2.0.0",
         "normality >= 2.4.0, < 3.0.0",
         "fakeredis >=2.11.2, < 3.0.0",
-        "sqlalchemy >= 2.0.4, < 3.0.0",
+        "sqlalchemy >= 1.3.2, < 3.0.0",
         "structlog >= 20.2.0, < 24.0.0",
         "colorama >= 0.4.4, < 1.0.0",
         "pika >= 1.3.1, < 2.0.0",


### PR DESCRIPTION
- [x] run the SQLAlchemy tests with a Postgres connection
- [x] use the `future=True` flag in the `create_engine` method in order to use the SQLA 2+ API in SQLA 1.4 (as per [the docs](https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#migration-to-2-0-step-four-use-the-future-flag-on-engine))