### PR TITLE
Fix SQLAlchemy calls 

### DIFF
--- a/servicelayer/tags.py
+++ b/servicelayer/tags.py
@@ -50,7 +50,7 @@ class Tags(object):
             stmt = stmt.where(self.table.c.timestamp >= since)
         with self.engine.connect() as conn:
             rp = conn.execute(stmt)
-        row = rp.fetchone()
+            row = rp.fetchone()
         if row is not None:
             return row.value
 
@@ -61,7 +61,7 @@ class Tags(object):
             stmt = stmt.where(self.table.c.timestamp >= since)
         with self.engine.connect() as conn:
             rp = conn.execute(stmt)
-        count = rp.scalar()
+            count = rp.scalar()
         return count > 0
 
     def _store_values(self, conn, row):


### PR DESCRIPTION
We discovered a bug when trying to use the latest version of `servicelayer` in `memorious`. The `memorious` tests would fail when run against a SQLite databse. 

The cause of this failure stems from the fact that SQLite and PostgreSQL behave differently when it comes to streaming DB results. 
* PostgreSQL implements client-side cursors, and allows for buffering the results of a query in memory before returning a result
* SQLite implements server-side cursors and results are unbuffered. 

The bug surfaced when running `memorious` tests that were using `servicelayer` to query a local SQLite database. Calls such as `fetchone` and `scalar` were being run outside of the open DB connection, and were failing. This commit fixes the bug. 