### PR TITLE
Add basic Prometheus instrumentation for workers

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ sqlalchemy==2.0.4
 structlog==23.1.0
 colorama==0.4.6
 pika==1.3.2
+prometheus-client==0.17.1

--- a/servicelayer/settings.py
+++ b/servicelayer/settings.py
@@ -49,3 +49,7 @@ QUEUE_INDEX = "index_queue"
 SENTRY_DSN = env.get("SENTRY_DSN")
 SENTRY_ENVIRONMENT = env.get("SENTRY_ENVIRONMENT", "")
 SENTRY_RELEASE = env.get("SENTRY_RELEASE", "")
+
+# Instrumentation
+PROMETHEUS_ENABLED = env.to_bool("PROMETHEUS_ENABLED", False)
+PROMETHEUS_PORT = env.to_int("PROMETHEUS_PORT", 9090)

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         "structlog >= 20.2.0, < 24.0.0",
         "colorama >= 0.4.4, < 1.0.0",
         "pika >= 1.3.1, < 2.0.0",
+        "prometheus-client >= 0.17.1, < 0.18.0",
     ],
     extras_require={
         "amazon": ["boto3 >= 1.11.9, <2.0.0"],

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -18,110 +18,111 @@ class CountingWorker(worker.Worker):
     def handle(self, task):
         self.test_done += 1
 
-        
+
 class FailingWorker(worker.Worker):
     def handle(self, task):
         raise Exception("Woops")
-        
-        
+
+
 class NoOpWorker(worker.Worker):
     def handle(self, task):
         pass
 
 
-def setup_method(self, _):
-      # This relies on internal implementation details of the client to reset
-      # previously collected metrics before every test execution. Unfortunately,
-      # there is no clean way of achieving the same thing that doesn't add a lot
-      # of complexity to the test and application code.
-      collectors = REGISTRY._collector_to_names.keys()
-      for collector in collectors:
-          if isinstance(collector, MetricWrapperBase):
-              collector._metrics.clear()
-              collector._metric_init()
+class PrometheusTests:
+    def setup_method(self, method):
+        # This relies on internal implementation details of the client to reset
+        # previously collected metrics before every test execution. Unfortunately,
+        # there is no clean way of achieving the same thing that doesn't add a lot
+        # of complexity to the test and application code.
+        collectors = REGISTRY._collector_to_names.keys()
+        for collector in collectors:
+            if isinstance(collector, MetricWrapperBase):
+                collector._metrics.clear()
+                collector._metric_init()
 
-  def test_prometheus_succeeded():
-      conn = get_fakeredis()
-      worker = CountingWorker(conn=conn, stages=["ingest"])
-      job = Job.create(conn, "test")
-      stage = job.get_stage("ingest")
-      stage.queue({}, {})
-      worker.sync()
+    def test_prometheus_succeeded(self):
+        conn = get_fakeredis()
+        worker = CountingWorker(conn=conn, stages=["ingest"])
+        job = Job.create(conn, "test")
+        stage = job.get_stage("ingest")
+        stage.queue({}, {})
+        worker.sync()
 
-      labels = {"stage": "ingest"}
-      success_labels = {"stage": "ingest", "retries": "0"}
+        labels = {"stage": "ingest"}
+        success_labels = {"stage": "ingest", "retries": "0"}
 
-      started = REGISTRY.get_sample_value("task_started_total", labels)
-      succeeded = REGISTRY.get_sample_value("task_succeeded_total", success_labels)
+        started = REGISTRY.get_sample_value("task_started_total", labels)
+        succeeded = REGISTRY.get_sample_value("task_succeeded_total", success_labels)
 
-      # Under the hood, histogram metrics create multiple time series tracking
-      # the number and sum of observations, as well as individual histogram buckets.
-      duration_sum = REGISTRY.get_sample_value("task_duration_seconds_sum", labels)
-      duration_count = REGISTRY.get_sample_value(
-          "task_duration_seconds_count",
-          labels,
-      )
+        # Under the hood, histogram metrics create multiple time series tracking
+        # the number and sum of observations, as well as individual histogram buckets.
+        duration_sum = REGISTRY.get_sample_value("task_duration_seconds_sum", labels)
+        duration_count = REGISTRY.get_sample_value(
+            "task_duration_seconds_count",
+            labels,
+        )
 
-      assert started == 1
-      assert succeeded == 1
-      assert duration_sum > 0
-      assert duration_count == 1
+        assert started == 1
+        assert succeeded == 1
+        assert duration_sum > 0
+        assert duration_count == 1
 
-  def test_prometheus_failed():
-      conn = get_fakeredis()
-      worker = FailingWorker(conn=conn, stages=["ingest"])
-      job = Job.create(conn, "test")
-      stage = job.get_stage("ingest")
-      stage.queue({}, {})
-      labels = {"stage": "ingest"}
+    def test_prometheus_failed(self):
+        conn = get_fakeredis()
+        worker = FailingWorker(conn=conn, stages=["ingest"])
+        job = Job.create(conn, "test")
+        stage = job.get_stage("ingest")
+        stage.queue({}, {})
+        labels = {"stage": "ingest"}
 
-      worker.sync()
+        worker.sync()
 
-      assert REGISTRY.get_sample_value("task_started_total", labels) == 1
-      assert REGISTRY.get_sample_value(
-          "task_failed_total",
-          {
-              "stage": "ingest",
-              "retries": "0",
-              "failed_permanently": "False",
-          },
-      )
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 1
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "0",
+                "failed_permanently": "False",
+            },
+        )
 
-      worker.sync()
+        worker.sync()
 
-      assert REGISTRY.get_sample_value("task_started_total", labels) == 2
-      assert REGISTRY.get_sample_value(
-          "task_failed_total",
-          {
-              "stage": "ingest",
-              "retries": "1",
-              "failed_permanently": "False",
-          },
-      )
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 2
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "1",
+                "failed_permanently": "False",
+            },
+        )
 
-      worker.sync()
+        worker.sync()
 
-      assert REGISTRY.get_sample_value("task_started_total", labels) == 3
-      assert REGISTRY.get_sample_value(
-          "task_failed_total",
-          {
-              "stage": "ingest",
-              "retries": "2",
-              "failed_permanently": "False",
-          },
-      )
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 3
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "2",
+                "failed_permanently": "False",
+            },
+        )
 
-      worker.sync()
+        worker.sync()
 
-      assert REGISTRY.get_sample_value("task_started_total", labels) == 4
-      assert REGISTRY.get_sample_value(
-          "task_failed_total",
-          {
-              "stage": "ingest",
-              "retries": "3",
-              "failed_permanently": "True",
-          },
-      )
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 4
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "3",
+                "failed_permanently": "True",
+            },
+        )
 
 
 def test_run():

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,5 +1,7 @@
 from unittest import TestCase
 import pytest
+from prometheus_client import REGISTRY
+from prometheus_client.metrics import MetricWrapperBase
 
 from servicelayer.cache import get_fakeredis
 from servicelayer.jobs import Job
@@ -17,7 +19,23 @@ class CountingWorker(worker.Worker):
         self.test_done += 1
 
 
+class FailingWorker(worker.Worker):
+    def handle(self, task):
+        raise Exception("Woops")
+
+
 class WorkerTest(TestCase):
+    def setup_method(self, _):
+        # This relies on internal implementation details of the client to reset
+        # previously collected metrics before every test execution. Unfortunately,
+        # there is no clean way of achieving the same thing that doesn't add a lot
+        # of complexity to the test and application code.
+        collectors = REGISTRY._collector_to_names.keys()
+        for collector in collectors:
+            if isinstance(collector, MetricWrapperBase):
+                collector._metrics.clear()
+                collector._metric_init()
+
     def test_run(self):
         conn = get_fakeredis()
         operation = "lala"
@@ -53,3 +71,86 @@ class WorkerTest(TestCase):
             assert exc.code == 5, exc.code
         with pytest.raises(SystemExit) as exc:  # noqa
             worker._handle_signal(5, None)
+
+    def test_prometheus_succeeded(self):
+        conn = get_fakeredis()
+        worker = CountingWorker(conn=conn, stages=["ingest"])
+        job = Job.create(conn, "test")
+        stage = job.get_stage("ingest")
+        stage.queue({}, {})
+        worker.sync()
+
+        labels = {"stage": "ingest"}
+        success_labels = {"stage": "ingest", "retries": "0"}
+
+        started = REGISTRY.get_sample_value("task_started_total", labels)
+        succeeded = REGISTRY.get_sample_value("task_succeeded_total", success_labels)
+
+        # Under the hood, histogram metrics create multiple time series tracking
+        # the number and sum of observations, as well as individual histogram buckets.
+        duration_sum = REGISTRY.get_sample_value("task_duration_seconds_sum", labels)
+        duration_count = REGISTRY.get_sample_value(
+            "task_duration_seconds_count",
+            labels,
+        )
+
+        assert started == 1
+        assert succeeded == 1
+        assert duration_sum > 0
+        assert duration_count == 1
+
+    def test_prometheus_failed(self):
+        conn = get_fakeredis()
+        worker = FailingWorker(conn=conn, stages=["ingest"])
+        job = Job.create(conn, "test")
+        stage = job.get_stage("ingest")
+        stage.queue({}, {})
+        labels = {"stage": "ingest"}
+
+        worker.sync()
+
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 1
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "0",
+                "failed_permanently": "False",
+            },
+        )
+
+        worker.sync()
+
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 2
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "1",
+                "failed_permanently": "False",
+            },
+        )
+
+        worker.sync()
+
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 3
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "2",
+                "failed_permanently": "False",
+            },
+        )
+
+        worker.sync()
+
+        assert REGISTRY.get_sample_value("task_started_total", labels) == 4
+        assert REGISTRY.get_sample_value(
+            "task_failed_total",
+            {
+                "stage": "ingest",
+                "retries": "3",
+                "failed_permanently": "True",
+            },
+        )


### PR DESCRIPTION
This PR adds basic Prometheus instrumentation for workers, i.e. both Aleph workers and ingest-file workers will expose these metrics once upgraded to the latest servicelayer version.

The following metrics are exposed:

* **task_started_total**: Counter for the total number of tasks that have started processing. Has labels for `stage` (e.g. `ingest`, `reindex`, `xref`, …) and `retries` (this would allow to find out how many tasks were successful processed only after n retries).

* **task_succeeded_total**: Counter for the total number of successfully processed tasks. Has labels for `stage`  and `retries`.

* **task_failed_total**: Counter for the total number of failed tasks. This includes tasks that failed non-permanently and will be retried as well as tasks that have already exhausted the maximum number of retries. In addition to the `stage` and `retries` labels this has a `failed_permanently` label.

* **task_duration_seconds**: Histogram that tracks task processing duration. Histogram metrics require setting fixed buckets. As task duration can vary quite a bit depending on stage (e.g. reindex tasks are usually super fast, whereas xrefs take longer), I’ve set them up to cover a wide range for now (250ms to 24h), we might want to adjust them later based on the metrics we collected in production.

I think it would be nice if we could also expose the wait time of a task (difference between the time the task was created and the time a worker started processing it) and/or the total time from creation to success/failure, as these are metrics that are directly relevant to end users. However, I don’t think we currently store task creation time.

Technically, `task_succeeded_total` is redundant: Under the hood, histogram metrics store several other metrics, including the sum of all observations and the count of observations. However, these are often named confusingly (e.g. `task_duration_seconds_count`). Also, `task_succeeded_total` has an additional `retries` label, so I think it’s worth tracking the success count separately.

### How to test this

Start Aleph on your computer.

```
# Stop the current ingest-file container
docker compose -f docker-compose.dev.yml stop ingest-file

# Start a new ingest-file container
docker compose -f docker-compose.dev.yml run --rm --env PROMETHEUS_ENABLED=true -p=9090:9090 ingest-file

# Install servicelayer from git
pip install git+https://github.com/alephdata/servicelayer@feature/prometheus

# Run the ingest-file worker
ingestors process
```

(You follow the same steps analogously for the Aleph worker.)

The logs should include a message indicating that a metrics server is running on port 9090. You should now be able to access logs on your host machine:

```
curl http://localhost:9090/metrics
```

Open the Aleph UI, upload a few documents, and check the exposed metrics again.