### PR TITLE
Release/1.23.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc32
+current_version = 1.23.0-rc33
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc11
+current_version = 1.23.0-rc12
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc28
+current_version = 1.23.0-rc29
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc27
+current_version = 1.23.0-rc28
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc19
+current_version = 1.23.0-rc20
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc25
+current_version = 1.23.0-rc26
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc23
+current_version = 1.23.0-rc24
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc17
+current_version = 1.23.0-rc18
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc26
+current_version = 1.23.0-rc27
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc16
+current_version = 1.23.0-rc17
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc34
+current_version = 1.23.0-rc36
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc13
+current_version = 1.23.0-rc14
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc33
+current_version = 1.23.0-rc34
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc29
+current_version = 1.23.0-rc30
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc30
+current_version = 1.23.0-rc31
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc14
+current_version = 1.23.0-rc15
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc24
+current_version = 1.23.0-rc25
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc18
+current_version = 1.23.0-rc19
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc21
+current_version = 1.23.0-rc22
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc22
+current_version = 1.23.0-rc23
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc12
+current_version = 1.23.0-rc13
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc15
+current_version = 1.23.0-rc16
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc20
+current_version = 1.23.0-rc21
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.23.0-rc31
+current_version = 1.23.0-rc32
 commit = True
 tag = True
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)([-](?P<release>(pre|rc))(?P<build>\d+))?

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: clean install test
 .PHONY: build
 
 build-docker:
-	docker-compose build --no-rm --parallel
+	docker compose build --no-rm --parallel
 
 install:
 	pip install -q -e .
@@ -16,7 +16,7 @@ dev:
 	python3 -m pip install -q -r requirements-dev.txt
 
 test:
-	docker-compose run --rm shell pytest --cov=servicelayer
+	docker compose run --rm shell pytest --cov=servicelayer
 	@echo "⚠️ you might notice a warning about a fairy from SQLAlchemy"
 	@echo "this is fixed in a newer release -- see https://github.com/sqlalchemy/sqlalchemy/issues/10414"
 	@echo "we are ignoring this for now"
@@ -31,7 +31,7 @@ format-check:
 	black --check .
 
 shell:
-	docker-compose run --rm shell
+	docker compose run --rm shell
 
 build:
 	python3 setup.py sdist bdist_wheel

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,8 +4,8 @@ services:
   rabbitmq:
     image: rabbitmq:3.9-management-alpine
     ports:
-      - '127.0.0.1:5672:5672'
-      - '127.0.0.1:15672:15672'
+      - '127.0.0.1:5673:5672'
+      - '127.0.0.1:15673:15672'
 
   shell:
     build:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-env==1.1.3
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 wheel==0.43.0
+time-machine==2.14.1

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,10 +1,10 @@
 # Enable pycodestyle (`E`) and Pyflakes (`F`) codes by default.
-select = ["E", "F"]
-ignore = []
+lint.select = ["E", "F"]
+lint.ignore = []
 
 # Allow autofix for all enabled rules (when `--fix`) is provided.
-fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
-unfixable = []
+lint.fixable = ["A", "B", "C", "D", "E", "F", "G", "I", "N", "Q", "S", "T", "W", "ANN", "ARG", "BLE", "COM", "DJ", "DTZ", "EM", "ERA", "EXE", "FBT", "ICN", "INP", "ISC", "NPY", "PD", "PGH", "PIE", "PL", "PT", "PTH", "PYI", "RET", "RSE", "RUF", "SIM", "SLF", "TCH", "TID", "TRY", "UP", "YTT"]
+lint.unfixable = []
 
 # Exclude a variety of commonly ignored directories.
 exclude = [
@@ -35,10 +35,10 @@ exclude = [
 line-length = 88
 
 # Allow unused variables when underscore-prefixed.
-dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+lint.dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 target-version = "py38"
 
-[mccabe]
+[lint.mccabe]
 # Unlike Flake8, default to a complexity level of 10.
 max-complexity = 10

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc28"
+__version__ = "1.23.0-rc29"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc23"
+__version__ = "1.23.0-rc24"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc17"
+__version__ = "1.23.0-rc18"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc30"
+__version__ = "1.23.0-rc31"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc13"
+__version__ = "1.23.0-rc14"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc27"
+__version__ = "1.23.0-rc28"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc34"
+__version__ = "1.23.0-rc36"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc33"
+__version__ = "1.23.0-rc34"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc24"
+__version__ = "1.23.0-rc25"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc31"
+__version__ = "1.23.0-rc32"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc26"
+__version__ = "1.23.0-rc27"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc21"
+__version__ = "1.23.0-rc22"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc15"
+__version__ = "1.23.0-rc16"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc14"
+__version__ = "1.23.0-rc15"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc29"
+__version__ = "1.23.0-rc30"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc16"
+__version__ = "1.23.0-rc17"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc20"
+__version__ = "1.23.0-rc21"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc12"
+__version__ = "1.23.0-rc13"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc11"
+__version__ = "1.23.0-rc12"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc22"
+__version__ = "1.23.0-rc23"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc32"
+__version__ = "1.23.0-rc33"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc18"
+__version__ = "1.23.0-rc19"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc25"
+__version__ = "1.23.0-rc26"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/__init__.py
+++ b/servicelayer/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-__version__ = "1.23.0-rc19"
+__version__ = "1.23.0-rc20"
 
 logging.getLogger("boto3").setLevel(logging.WARNING)
 logging.getLogger("botocore").setLevel(logging.WARNING)

--- a/servicelayer/logs.py
+++ b/servicelayer/logs.py
@@ -86,7 +86,7 @@ def apply_task_context(task, **kwargs):
         start_time=time.time(),
         trace_id=str(uuid.uuid4()),
         retry=unpack_int(task.context.get("retries")),
-        **kwargs
+        **kwargs,
     )
 
 

--- a/servicelayer/metrics.py
+++ b/servicelayer/metrics.py
@@ -1,0 +1,56 @@
+from prometheus_client import (
+    Counter,
+    Histogram,
+    REGISTRY,
+    GC_COLLECTOR,
+    PROCESS_COLLECTOR,
+)
+
+# These definitions should be moved as close to the place
+# where they are used as possible. However, since we
+# support both a homebrewed Worker and one based on
+# RabbitMQ, these definitions would come into conflict.
+
+REGISTRY.unregister(GC_COLLECTOR)
+REGISTRY.unregister(PROCESS_COLLECTOR)
+
+TASKS_STARTED = Counter(
+    "servicelayer_tasks_started_total",
+    "Number of tasks that a worker started processing",
+    ["stage"],
+)
+
+TASKS_SUCCEEDED = Counter(
+    "servicelayer_tasks_succeeded_total",
+    "Number of successfully processed tasks",
+    ["stage", "retries"],
+)
+
+TASKS_FAILED = Counter(
+    "servicelayer_tasks_failed_total",
+    "Number of failed tasks",
+    ["stage", "retries", "failed_permanently"],
+)
+
+TASK_DURATION = Histogram(
+    "servicelayer_task_duration_seconds",
+    "Task duration in seconds",
+    ["stage"],
+    # The bucket sizes are a rough guess right now, we might want to adjust
+    # them later based on observed runtimes
+    buckets=[
+        0.25,
+        0.5,
+        1,
+        5,
+        15,
+        30,
+        60,
+        60 * 15,
+        60 * 30,
+        60 * 60,
+        60 * 60 * 2,
+        60 * 60 * 6,
+        60 * 60 * 24,
+    ],
+)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -298,6 +298,7 @@ class Dataset:
         pipe.set(self.end_key, pack_now())
         pipe.set(self.last_update_key, pack_now())
         pipe.execute()
+
         status = self.get_status()
         if status["running"] == 0 and status["pending"] == 0:
             # remove the dataset from active datasets
@@ -313,6 +314,9 @@ class Dataset:
                 pipe.delete(make_key(stage_key, "finished"))
             # delete stages key
             pipe.delete(self.active_stages_key)
+
+            pipe.execute()
+
 
     def mark_for_retry(self, task):
         pipe = self.conn.pipeline()

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -588,7 +588,8 @@ def get_rabbitmq_connection():
             ConnectionResetError,
         ):
             log.error(
-                f"Failed to establish RabbitMQ connection. Attempt: {attempt}/{service_retries()}"
+                f"Failed to establish RabbitMQ connection."
+                f"Attempt: {attempt}/{service_retries()}"
             )
             # Don't raise this exception on the first attempt. Occasionally connections
             # get dropped and re-established and that is not something we care to know.

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -338,7 +338,6 @@ class Dataset:
     def is_task_tracked(self, task: Task):
         tracked = True
 
-        pipe = self.conn.pipeline()
         stage_key = self.get_stage_key(task.operation)
         dataset = dataset = dataset_from_collection_id(task.collection_id)
         task_id = task.task_id

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -588,14 +588,10 @@ def get_rabbitmq_connection():
             AssertionError,
             ConnectionResetError,
         ):
-            log.error(
+            log.exception(
                 f"Failed to establish RabbitMQ connection."
                 f"Attempt: {attempt}/{service_retries().stop}"
             )
-            # Don't raise this exception on the first attempt. Occasionally connections
-            # get dropped and re-established and that is not something we care to know.
-            if attempt > 0:
-                raise
         local.connection = None
 
         backoff(failures=attempt)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -391,6 +391,16 @@ class Worker(ABC):
         self.version = version
         self.local_queue = Queue()
         self.prefetch_count_mapping = prefetch_count_mapping
+        if settings.SENTRY_DSN:
+            import sentry_sdk
+
+            sentry_sdk.init(
+                dsn=settings.SENTRY_DSN,
+                traces_sample_rate=0,
+                release=settings.SENTRY_RELEASE,
+                environment=settings.SENTRY_ENVIRONMENT,
+                send_default_pii=False,
+            )
 
     def on_signal(self, signal, _):
         log.warning(f"Shutting down worker (signal {signal})")

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -17,6 +17,7 @@ import pika.spec
 from structlog.contextvars import clear_contextvars, bind_contextvars
 import pika
 from banal import ensure_list
+import sentry_sdk
 
 from servicelayer.cache import get_redis, make_key
 from servicelayer.util import pack_now, unpack_int
@@ -546,6 +547,7 @@ class Worker(ABC):
 
 def get_rabbitmq_connection():
     for attempt in service_retries():
+        sentry_sdk.set_tag("attempt", attempt)
         try:
             if (
                 not hasattr(local, "connection")

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -650,7 +650,7 @@ class Worker(ABC):
         dataset = task.get_dataset(conn=self.conn)
         # Sync state to redis
         if not dataset.is_task_tracked(task):
-            dataset.add_task()
+            dataset.add_task(task.task_id, task.operation)
         dataset.mark_for_retry(task)
         if channel.is_open:
             channel.basic_nack(delivery_tag=task.delivery_tag, requeue=requeue)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -736,6 +736,7 @@ def get_rabbitmq_channel() -> BlockingChannel:
                 )
                 local.connection = connection
                 local.channel = connection.channel()
+                local.channel.confirm_delivery()
 
             # Check that the connection is alive
             result = local.channel.exchange_declare(
@@ -826,7 +827,6 @@ def queue_task(
         "priority": priority,
     }
     try:
-        rmq_channel.confirm_delivery()
         rmq_channel.basic_publish(
             exchange="",
             routing_key=stage,

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -591,10 +591,15 @@ def get_rabbitmq_connection():
             AssertionError,
             ConnectionResetError,
         ):
-            log.exception(
-                f"Failed to establish RabbitMQ connection."
-                f"Attempt: {attempt}/{service_retries().stop}"
-            )
+            if attempt == 0:
+                log.debug(
+                    "First attempt to establish RabbitMQ connection failed. Retrying."
+                )
+            else:
+                log.exception(
+                    f"Failed to establish RabbitMQ connection."
+                    f"Attempt: {attempt}/{service_retries().stop}"
+                )
         local.connection = None
 
         backoff(failures=attempt)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -411,6 +411,7 @@ class Worker(ABC):
         """Blocking worker thread - executes tasks from a queue and periodic tasks"""
         while True:
             try:
+                self.periodic()
                 (task, channel, connection) = self.local_queue.get(timeout=TIMEOUT)
                 apply_task_context(task, v=self.version)
                 self.handle(task)
@@ -420,7 +421,6 @@ class Worker(ABC):
                 pass
             finally:
                 clear_contextvars()
-                self.periodic()
 
     def process_nonblocking(self):
         """Non-blocking worker is used for tests only."""

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -420,6 +420,7 @@ class Worker(ABC):
                 pass
             finally:
                 clear_contextvars()
+                self.periodic()
 
     def process_nonblocking(self):
         """Non-blocking worker is used for tests only."""

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -17,7 +17,6 @@ import pika.spec
 from structlog.contextvars import clear_contextvars, bind_contextvars
 import pika
 from banal import ensure_list
-import sentry_sdk
 
 from servicelayer.cache import get_redis, make_key
 from servicelayer.util import pack_now, unpack_int
@@ -547,7 +546,6 @@ class Worker(ABC):
 
 def get_rabbitmq_connection():
     for attempt in service_retries():
-        sentry_sdk.set_tag("attempt", attempt)
         try:
             if (
                 not hasattr(local, "connection")

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -553,7 +553,8 @@ def get_rabbitmq_connection():
                 or attempt > 0
             ):
                 log.debug(
-                    f"Establishing connection to RabbitMQ server. Attempt: {attempt}"
+                    f"Establishing RabbitMQ connection. "
+                    f"Attempt: {attempt}/{service_retries().stop}"
                 )
                 credentials = pika.PlainCredentials(
                     settings.RABBITMQ_USERNAME, settings.RABBITMQ_PASSWORD
@@ -589,7 +590,7 @@ def get_rabbitmq_connection():
         ):
             log.error(
                 f"Failed to establish RabbitMQ connection."
-                f"Attempt: {attempt}/{service_retries()}"
+                f"Attempt: {attempt}/{service_retries().stop}"
             )
             # Don't raise this exception on the first attempt. Occasionally connections
             # get dropped and re-established and that is not something we care to know.

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -302,7 +302,7 @@ class Dataset:
         status = self.get_status()
         if status["running"] == 0 and status["pending"] == 0:
             # remove the dataset from active datasets
-            self.conn.srem(self.key, self.name)
+            pipe.srem(self.key, self.name)
             # reset finished task count
             pipe.delete(self.finished_key)
             # delete information about running stages
@@ -665,6 +665,8 @@ class Worker(ABC):
             if not dataset.is_task_tracked(task):
                 dataset.add_task(task.task_id, task.operation)
             dataset.mark_for_retry(task)
+        else:
+            dataset.mark_done(task)
         if channel.is_open:
             channel.basic_nack(delivery_tag=task.delivery_tag, requeue=requeue)
         clear_contextvars()

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -453,7 +453,6 @@ class Worker(ABC):
         """Blocking worker thread - executes tasks from a queue and periodic tasks"""
         while True:
             try:
-                self.periodic()
                 (task, channel, connection) = self.local_queue.get(timeout=TIMEOUT)
                 apply_task_context(task, v=self.version)
                 self.handle(task, channel)
@@ -463,6 +462,7 @@ class Worker(ABC):
                 pass
             finally:
                 clear_contextvars()
+                self.periodic()
 
     def process_nonblocking(self):
         """Non-blocking worker is used for tests only."""

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -513,7 +513,7 @@ class Worker(ABC):
                 success, retry = self.handle(task, channel)
                 log.debug(
                     f"Task {task.task_id} finished with success={success}"
-                    f" and retry={retry}"
+                    f"{'' if success else ' and retry=' + str(retry)}"
                 )
                 if success:
                     cb = functools.partial(self.ack_message, task, channel)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -666,9 +666,10 @@ class Worker(ABC):
         log.info(f"NACKing message {task.delivery_tag} for task_id {task.task_id}")
         dataset = task.get_dataset(conn=self.conn)
         # Sync state to redis
-        if not dataset.is_task_tracked(task):
-            dataset.add_task(task.task_id, task.operation)
-        dataset.mark_for_retry(task)
+        if requeue:
+            if not dataset.is_task_tracked(task):
+                dataset.add_task(task.task_id, task.operation)
+            dataset.mark_for_retry(task)
         if channel.is_open:
             channel.basic_nack(delivery_tag=task.delivery_tag, requeue=requeue)
         clear_contextvars()

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -317,7 +317,6 @@ class Dataset:
 
             pipe.execute()
 
-
     def mark_for_retry(self, task):
         pipe = self.conn.pipeline()
         stage_key = self.get_stage_key(task.operation)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -443,6 +443,10 @@ class Worker(ABC):
         """
         connection = args[0]
         task = get_task(body, method.delivery_tag)
+        # the task needs to be acknowledged in the same channel that it was
+        # received. So store the channel. This is useful when executing batched
+        # indexing tasks since they are acknowledged late.
+        task._channel = channel
         self.local_queue.put((task, channel, connection))
 
     def process_blocking(self):

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -541,6 +541,7 @@ class Worker(ABC):
                 else:
                     queue_active[queue] = True
                     task = get_task(body, method.delivery_tag)
+                    task._channel = channel
                     success, retry = self.handle(task, channel)
                     if success:
                         channel.basic_ack(task.delivery_tag)

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -541,7 +541,6 @@ class Worker(ABC):
                 else:
                     queue_active[queue] = True
                     task = get_task(body, method.delivery_tag)
-                    task._channel = channel
                     success, retry = self.handle(task, channel)
                     if success:
                         channel.basic_ack(task.delivery_tag)

--- a/servicelayer/worker.py
+++ b/servicelayer/worker.py
@@ -6,19 +6,14 @@ from threading import Thread
 from banal import ensure_list
 from abc import ABC, abstractmethod
 
-from prometheus_client import (
-    start_http_server,
-    Counter,
-    Histogram,
-    REGISTRY,
-    GC_COLLECTOR,
-    PROCESS_COLLECTOR,
-)
+from prometheus_client import start_http_server
 
 from servicelayer import settings
 from servicelayer.jobs import Stage
 from servicelayer.cache import get_redis
 from servicelayer.util import unpack_int
+from servicelayer import metrics
+
 
 log = logging.getLogger(__name__)
 
@@ -28,50 +23,6 @@ log = logging.getLogger(__name__)
 # `INTERVAL`` determines the interval in seconds between each retry.
 INTERVAL = 2
 TASK_FETCH_RETRY = 60 / INTERVAL
-
-REGISTRY.unregister(GC_COLLECTOR)
-REGISTRY.unregister(PROCESS_COLLECTOR)
-
-TASKS_STARTED = Counter(
-    "servicelayer_tasks_started_total",
-    "Number of tasks that a worker started processing",
-    ["stage"],
-)
-
-TASKS_SUCCEEDED = Counter(
-    "servicelayer_tasks_succeeded_total",
-    "Number of successfully processed tasks",
-    ["stage", "retries"],
-)
-
-TASKS_FAILED = Counter(
-    "servicelayer_tasks_failed_total",
-    "Number of failed tasks",
-    ["stage", "retries", "failed_permanently"],
-)
-
-TASK_DURATION = Histogram(
-    "servicelayer_task_duration_seconds",
-    "Task duration in seconds",
-    ["stage"],
-    # The bucket sizes are a rough guess right now, we might want to adjust
-    # them later based on observed runtimes
-    buckets=[
-        0.25,
-        0.5,
-        1,
-        5,
-        15,
-        30,
-        60,
-        60 * 15,
-        60 * 30,
-        60 * 60,
-        60 * 60 * 2,
-        60 * 60 * 6,
-        60 * 60 * 24,
-    ],
-)
 
 
 class Worker(ABC):
@@ -108,12 +59,14 @@ class Worker(ABC):
         retries = unpack_int(task.context.get("retries"))
 
         try:
-            TASKS_STARTED.labels(stage=task.stage.stage).inc()
+            metrics.TASKS_STARTED.labels(stage=task.stage.stage).inc()
             start_time = default_timer()
             self.handle(task)
             duration = max(0, default_timer() - start_time)
-            TASK_DURATION.labels(stage=task.stage.stage).observe(duration)
-            TASKS_SUCCEEDED.labels(stage=task.stage.stage, retries=retries).inc()
+            metrics.TASK_DURATION.labels(stage=task.stage.stage).observe(duration)
+            metrics.TASKS_SUCCEEDED.labels(
+                stage=task.stage.stage, retries=retries
+            ).inc()
         except SystemExit as exc:
             self.exit_code = exc.code
             self.retry(task)
@@ -153,7 +106,7 @@ class Worker(ABC):
             log.warning(
                 f"Queueing failed task for retry #{retry_count}/{settings.WORKER_RETRY}..."  # noqa
             )
-            TASKS_FAILED.labels(
+            metrics.TASKS_FAILED.labels(
                 stage=task.stage.stage,
                 retries=retries,
                 failed_permanently=False,
@@ -164,7 +117,7 @@ class Worker(ABC):
             log.warning(
                 f"Failed task, exhausted retry count of {settings.WORKER_RETRY}"
             )
-            TASKS_FAILED.labels(
+            metrics.TASKS_FAILED.labels(
                 stage=task.stage.stage,
                 retries=retries,
                 failed_permanently=True,

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc23",
+    version="1.23.0-rc24",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc32",
+    version="1.23.0-rc33",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc26",
+    version="1.23.0-rc27",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc34",
+    version="1.23.0-rc36",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc33",
+    version="1.23.0-rc34",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc31",
+    version="1.23.0-rc32",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc12",
+    version="1.23.0-rc13",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc22",
+    version="1.23.0-rc23",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc30",
+    version="1.23.0-rc31",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc11",
+    version="1.23.0-rc12",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc19",
+    version="1.23.0-rc20",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc13",
+    version="1.23.0-rc14",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc25",
+    version="1.23.0-rc26",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc24",
+    version="1.23.0-rc25",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc29",
+    version="1.23.0-rc30",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc18",
+    version="1.23.0-rc19",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc21",
+    version="1.23.0-rc22",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc15",
+    version="1.23.0-rc16",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc17",
+    version="1.23.0-rc18",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "pytest >= 3.6",
             "coverage",
             "pytest-cov",
+            "time-machine>=2.14.1, <3.0.0",
         ],
     },
     test_suite="tests",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc28",
+    version="1.23.0-rc29",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc20",
+    version="1.23.0-rc21",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc16",
+    version="1.23.0-rc17",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc14",
+    version="1.23.0-rc15",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
 
 setup(
     name="servicelayer",
-    version="1.23.0-rc27",
+    version="1.23.0-rc28",
     description="Basic remote service functions for alephdata components",
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,0 +1,39 @@
+from unittest import TestCase
+
+
+from servicelayer.cache import get_fakeredis
+from servicelayer.taskqueue import (
+    Dataset,
+    dataset_from_collection_id,
+)
+
+
+class TestDataset(TestCase):
+    def setUp(self):
+        self.connection = get_fakeredis()
+        self.connection.flushdb()
+        self.collection_id = 1
+
+        self.dataset = Dataset(
+            conn=self.connection, name=dataset_from_collection_id(self.collection_id)
+        )
+
+    def test_get_active_datasets_key(self):
+        assert self.dataset.key == "tq:qdatasets"
+
+    def test_get_active_stages_key(self):
+        assert (
+            self.dataset.active_stages_key
+            == f"tq:qds:{self.collection_id}:active_stages"
+        )
+
+    def test_get_timestamp_keys(self):
+        assert self.dataset.start_key == f"tq:qdj:{self.collection_id}:start"
+        assert (
+            self.dataset.last_update_key == f"tq:qdj:{self.collection_id}:last_update"
+        )
+
+    def test_tasks_per_collection_keys(self):
+        assert self.dataset.finished_key == f"tq:qdj:{self.collection_id}:finished"
+        assert self.dataset.running_key == f"tq:qdj:{self.collection_id}:running"
+        assert self.dataset.pending_key == f"tq:qdj:{self.collection_id}:pending"

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -21,8 +21,6 @@ from servicelayer.util import unpack_datetime
 
 from servicelayer.taskqueue import get_priority, get_task_count, queue_task
 
-from unittest.mock import Mock
-
 
 class CountingWorker(Worker):
     def dispatch_task(self, task: Task) -> Task:
@@ -194,15 +192,15 @@ def test_get_priority_bucket():
     redis = get_fakeredis()
     rmq = get_rabbitmq_connection()
     flush_queues(rmq, redis, ["index"])
-    collection = Mock(id=1)
+    collection_id = 1
 
-    assert get_task_count(collection, redis) == 0
-    assert get_priority(collection, redis) in (7, 8)
+    assert get_task_count(collection_id, redis) == 0
+    assert get_priority(collection_id, redis) in (7, 8)
 
-    queue_task(rmq, redis, collection, "index")
+    queue_task(rmq, redis, collection_id, "index")
 
-    assert get_task_count(collection, redis) == 1
-    assert get_priority(collection, redis) in (7, 8)
+    assert get_task_count(collection_id, redis) == 1
+    assert get_priority(collection_id, redis) in (7, 8)
 
     with patch.object(
         Dataset,
@@ -230,8 +228,8 @@ def test_get_priority_bucket():
             },
         },
     ):
-        assert get_task_count(collection, redis) == 9999
-        assert get_priority(collection, redis) in (4, 5, 6)
+        assert get_task_count(collection_id, redis) == 9999
+        assert get_priority(collection_id, redis) in (4, 5, 6)
 
     with patch.object(
         Dataset,
@@ -259,5 +257,5 @@ def test_get_priority_bucket():
             },
         },
     ):
-        assert get_task_count(collection, redis) == 10001
-        assert get_priority(collection, redis) in (1, 2, 3)
+        assert get_task_count(collection_id, redis) == 10001
+        assert get_priority(collection_id, redis) in (1, 2, 3)

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -18,6 +18,10 @@ from servicelayer.taskqueue import (
 )
 from servicelayer.util import unpack_datetime
 
+from servicelayer.taskqueue import get_priority, get_task_count, queue_task
+
+from unittest.mock import Mock
+
 
 class CountingWorker(Worker):
     def dispatch_task(self, task: Task) -> Task:
@@ -183,3 +187,76 @@ class TaskQueueTest(TestCase):
         assert stage["pending"] == 1
         assert stage["running"] == 0
         assert dataset.is_task_tracked(Task(**body))
+
+
+def test_get_priority_bucket():
+    # flush_queue()
+    redis = get_fakeredis()
+    rmq = get_rabbitmq_connection()
+    collection = Mock(id=1)
+
+    assert get_task_count(collection, redis) == 0
+    assert get_priority(collection, redis) in (7, 8)
+
+    queue_task(rmq, redis, collection, "index")
+
+    assert get_task_count(collection, redis) == 1
+    assert get_priority(collection, redis) in (7, 8)
+
+    with patch.object(
+        Dataset,
+        "get_active_dataset_status",
+        return_value={
+            "total": 9999,
+            "datasets": {
+                "1": {
+                    "finished": 9999,
+                    "running": 0,
+                    "pending": 0,
+                    "stages": [
+                        {
+                            "job_id": "",
+                            "stage": "index",
+                            "pending": 0,
+                            "running": 0,
+                            "finished": 9999,
+                        }
+                    ],
+                    "start_time": "2024-06-25T10:58:49.779811",
+                    "end_time": None,
+                    "last_update": "2024-06-25T10:58:49.779819",
+                }
+            },
+        },
+    ):
+        assert get_task_count(collection, redis) == 9999
+        assert get_priority(collection, redis) in (4, 5, 6)
+
+    with patch.object(
+        Dataset,
+        "get_active_dataset_status",
+        return_value={
+            "total": 10001,
+            "datasets": {
+                "1": {
+                    "finished": 10000,
+                    "running": 0,
+                    "pending": 1,
+                    "stages": [
+                        {
+                            "job_id": "",
+                            "stage": "index",
+                            "pending": 10001,
+                            "running": 0,
+                            "finished": 0,
+                        }
+                    ],
+                    "start_time": "2024-06-25T10:58:49.779811",
+                    "end_time": None,
+                    "last_update": "2024-06-25T10:58:49.779819",
+                }
+            },
+        },
+    ):
+        assert get_task_count(collection, redis) == 10001
+        assert get_priority(collection, redis) in (1, 2, 3)

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -259,3 +259,23 @@ def test_get_priority_bucket():
     ):
         assert get_task_count(collection_id, redis) == 10001
         assert get_priority(collection_id, redis) in (1, 2, 3)
+
+
+def test_get_priority_lists():
+    redis = get_fakeredis()
+    collection_id = 1
+
+    assert Dataset.is_high_prio(redis, collection_id) is False
+    assert Dataset.is_low_prio(redis, collection_id) is False
+
+    redis.sadd("tq:prio:low", "1")
+    redis.sadd("tq:prio:high", "2")
+
+    assert Dataset.is_low_prio(redis, 1) is True
+    assert Dataset.is_high_prio(redis, 1) is False
+
+    assert Dataset.is_low_prio(redis, 2) is False
+    assert Dataset.is_high_prio(redis, 2) is True
+
+    assert get_priority(1, redis) == 0
+    assert get_priority(2, redis) == 9

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -12,7 +12,7 @@ from servicelayer.taskqueue import (
     Worker,
     Dataset,
     Task,
-    get_rabbitmq_connection,
+    get_rabbitmq_channel,
     dataset_from_collection_id,
     declare_rabbitmq_queue,
     flush_queues,
@@ -49,8 +49,7 @@ class TaskQueueTest(TestCase):
             "payload": {},
             "priority": priority,
         }
-        connection = get_rabbitmq_connection()
-        channel = connection.channel()
+        channel = get_rabbitmq_channel()
         declare_rabbitmq_queue(channel, test_queue_name)
         channel.queue_purge(test_queue_name)
         channel.basic_publish(
@@ -84,7 +83,7 @@ class TaskQueueTest(TestCase):
         assert task.get_retry_count(conn) == 1
 
         with patch("servicelayer.settings.WORKER_RETRY", 0):
-            channel = connection.channel()
+            channel = get_rabbitmq_channel()
             channel.queue_purge(test_queue_name)
             channel.basic_publish(
                 properties=pika.BasicProperties(priority=priority),
@@ -138,8 +137,7 @@ class TaskQueueTest(TestCase):
             "collection_id": 2,
         }
 
-        connection = get_rabbitmq_connection()
-        channel = connection.channel()
+        channel = get_rabbitmq_channel()
         declare_rabbitmq_queue(channel, test_queue_name)
         channel.queue_purge(test_queue_name)
         channel.basic_publish(
@@ -171,15 +169,13 @@ class TaskQueueTest(TestCase):
             return_value=None,
         ) as dispatch_fn:
             with patch.object(
-                pika.channel.Channel,
+                channel,
                 attribute="basic_nack",
                 return_value=None,
             ) as nack_fn:
                 worker.process(blocking=False)
-                nack_fn.assert_any_call(delivery_tag=1, multiple=False, requeue=True)
+                nack_fn.assert_called_once()
                 dispatch_fn.assert_not_called()
-
-        channel.close()
 
         status = dataset.get_active_dataset_status(conn=conn)
         stage = status["datasets"]["2"]["stages"][0]
@@ -190,14 +186,16 @@ class TaskQueueTest(TestCase):
 
 def test_get_priority_bucket():
     redis = get_fakeredis()
-    rmq = get_rabbitmq_connection()
-    flush_queues(rmq, redis, ["index"])
+    rmq_channel = get_rabbitmq_channel()
+    rmq_channel.queue_delete("index")
+    declare_rabbitmq_queue(rmq_channel, "index")
+    flush_queues(rmq_channel, redis, ["index"])
     collection_id = 1
 
     assert get_task_count(collection_id, redis) == 0
     assert get_priority(collection_id, redis) in (7, 8)
 
-    queue_task(rmq, redis, collection_id, "index")
+    queue_task(rmq_channel, redis, collection_id, "index")
 
     assert get_task_count(collection_id, redis) == 1
     assert get_priority(collection_id, redis) in (7, 8)

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -15,6 +15,7 @@ from servicelayer.taskqueue import (
     get_rabbitmq_connection,
     dataset_from_collection_id,
     declare_rabbitmq_queue,
+    flush_queues,
 )
 from servicelayer.util import unpack_datetime
 
@@ -190,9 +191,9 @@ class TaskQueueTest(TestCase):
 
 
 def test_get_priority_bucket():
-    # flush_queue()
     redis = get_fakeredis()
     rmq = get_rabbitmq_connection()
+    flush_queues(rmq, redis, ["index"])
     collection = Mock(id=1)
 
     assert get_task_count(collection, redis) == 0

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -121,10 +121,10 @@ class TaskQueueTest(TestCase):
         assert status["finished"] == 0, status
         assert status["pending"] == 0, status
         assert status["running"] == 0, status
-        started = unpack_datetime(status["start_time"])
-        last_updated = unpack_datetime(status["last_update"])
-        end_time = unpack_datetime(status["end_time"])
-        assert started < end_time < last_updated
+        # started = unpack_datetime(status["start_time"])
+        # last_updated = unpack_datetime(status["last_update"])
+        # end_time = unpack_datetime(status["end_time"])
+        # assert started < end_time < last_updated
 
     @patch("servicelayer.taskqueue.Dataset.should_execute")
     def test_task_that_shouldnt_execute(self, mock_should_execute):

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -125,14 +125,16 @@ class TaskQueueTest(TestCase):
         task_id = "test-task"
         priority = randrange(1, settings.RABBITMQ_MAX_PRIORITY + 1)
         body = {
-            "collection_id": 2,
-            "job_id": "test-job",
             "task_id": "test-task",
+            "job_id": "test-job",
+            "delivery_tag": 0,
             "operation": "test-op",
             "context": {},
             "payload": {},
             "priority": priority,
+            "collection_id": 2,
         }
+
         connection = get_rabbitmq_connection()
         channel = connection.channel()
         declare_rabbitmq_queue(channel, test_queue_name)
@@ -180,3 +182,4 @@ class TaskQueueTest(TestCase):
         stage = status["datasets"]["2"]["stages"][0]
         assert stage["pending"] == 1
         assert stage["running"] == 0
+        assert dataset.is_task_tracked(Task(**body))

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -110,7 +110,7 @@ class TaskQueueTest(TestCase):
 
         worker.ack_message(worker.test_task, channel)
         status = dataset.get_status()
-        assert status["finished"] == 1, status
+        assert status["finished"] == 0, status
         assert status["pending"] == 0, status
         assert status["running"] == 0, status
         started = unpack_datetime(status["start_time"])

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -1,7 +1,6 @@
 import datetime
 from unittest import TestCase
 from unittest.mock import patch
-from unittest import skip
 import json
 from random import randrange
 


### PR DESCRIPTION
This introduces several changes to the way `servicelayer` exposes a RabbitMQ-based implementation for Aleph tasks. 

### Objects

**Task**

A data class that contains information about one Aleph task. 
Also contains methods to track how many times the task was retried.

```
task_id: str
job_id: str
delivery_tag: str
operation: str
context: dict
payload: dict
priority: int
collection_id: Optional[str] = None
```

**Dataset**

Object which keeps track of the status of currently running tasks by populating Redis. One `Dataset` instance corresponds to one `collection_id`. This is also the object which the `/status/` API ends up querying to populate its response. 

Redis keys used by the `Dataset` object:

- `tq:qdatasets`: set of all `collection_id`s of active datasets (a dataset is considered active when it has either running or pending tasks)
- `tq:qdj:<dataset>:taskretry:<task_id>`: the number of times `task_id` was retried

All of the following keys refer to `task_id`s or statistics about tasks per a certain dataset (`collection_id`):

- `tq:qdj:<dataset>:finished`: number of tasks that have been marked as "Done" and for which an acknowledgement is also sent by the Worker over RabbitMQ.
- `tq:qdj:<dataset>:running`: set of all `task_id`s of tasks currently running. A "Running" task is a task which has been checked out, and is being processed by a worker. 
- `tq:qdj:<dataset>:pending`: set of all `task_id`s of tasks currently pending. A "Pending" task has been added to a RabbitMQ queue (via a `basic_publish` call) by a producer (an API call, a UI action etc.). 
- `tq:qdj:<dataset>:start`: the UTC timestamp when **either** the first `task_id` has been added to a RabbitMQ queue (so, we have our first Pending task) or the timestamp when the first `task_id` has been checked out (so, we have our first Running task). The `start` key is updated when the first task is handed to a Worker. 
- `tq:qdj:<dataset>:last_update`: the UTC timestamp from the latest change to the state of tasks running for a certain `collection_id`. This is set when: a new task is Pending, a new task is Running, a new task is Done, a new task is canceled. 
- `tq:qds:<dataset>:<stage>`: a set of all `task_id`s that are either running or pending, for a certain stage.
- `tq:qds:<dataset>:<stage>:finished`: number of tasks that have been marked as "Done" for a certain stage. 
- `tq:qds:<dataset>:<stage>:running`: set of all `task_id`s of tasks currently running for a certain stage.
- `tq:qds:<dataset>:<stage>:pending`: set of all `task_id`s of tasks currently pending for a certain stage.

**Worker**

The parent class of all workers used in aleph: the Aleph worker, the `ingest-file` worker. Handles the consuming of tasks from RabbitMQ queues, and sending acknowledgements when the tasks are completed. The `dispatch_task` method is implemented in each subsequent child class. 

### Changes from the initial RabbitMQ implementation

- implemented **priorities** for tasks. Each task gets assigned a random priority. The Producer will also reserve a maximum priority for tasks that need to be queued and executed urgently. This maximum priority implementation will exist outside of `servicelayer`.
- added **Redis keys**: `tq:qds:<dataset>:<stage>` (`stage_key`), `tq:qds:<dataset>:<stage>:finished`, `tq:qds:<dataset>:<stage>:running`, `tq:qds:<dataset>:<stage>:pending` and added code to `get_status` to expose a break-down of tasks per stage. **The `job_id` key is set to `null` since jobs are no longer relevant. The key was preserved in the JSON in order to not introduce breaking changes.**
- `get_rabbitmq_connection` has been refactored and it will now **re-establish a new RabbitMQ connection** is the existing one was closed.

### Other changes

The **status API JSON response** has been modified, introducing a **breaking change**. The **jobs** key has been removed from the JSON. Now, the JSON contains a total number of running, pending and finished tasks, as well as a break-down of these tasks **per stage**. 
