### PR TITLE
Respect periodic timer

### DIFF
--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -424,7 +424,6 @@ class Worker(ABC):
                 pass
             finally:
                 clear_contextvars()
-                self.periodic()
 
     def process_nonblocking(self):
         """Non-blocking worker is used for tests only."""


### PR DESCRIPTION
Required for https://github.com/alephdata/aleph/pull/3739 to work. This removes the `periodic()` invocation from the task handler since the above PR introduces a proper timer.