### PR TITLE
Fix dataset timestamps

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,4 @@ pytest-env==1.1.3
 pytest-cov==5.0.0
 pytest-mock==3.14.0
 wheel==0.43.0
+time-machine==2.14.1

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -223,9 +223,7 @@ class Dataset:
         pipe.set(self.last_update_key, pack_now())
         pipe.execute()
 
-        status = self.get_status()
-        if status["running"] == 0 and status["pending"] == 0:
-            pipe = self.conn.pipeline()
+        if self.is_done():
             self.flush_status(pipe)
             pipe.execute()
 

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -219,7 +219,7 @@ class Dataset:
         pipe.sadd(make_key(stage_key, "pending"), task_id)
 
         pipe.sadd(self.pending_key, task_id)
-        pipe.set(self.start_key, pack_now())
+        pipe.set(self.start_key, pack_now(), nx=True)
         pipe.set(self.last_update_key, pack_now())
         pipe.execute()
 
@@ -269,7 +269,7 @@ class Dataset:
 
         pipe.srem(self.pending_key, task_id)
         pipe.sadd(self.running_key, task_id)
-        pipe.set(self.start_key, pack_now())
+        pipe.set(self.start_key, pack_now(), nx=True)
         pipe.set(self.last_update_key, pack_now())
         pipe.execute()
 

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -222,7 +222,6 @@ class Dataset:
         # update dataset timestamps
         pipe.set(self.start_key, pack_now(), nx=True)
         pipe.set(self.last_update_key, pack_now())
-        pipe.delete(self.end_key)
         pipe.execute()
 
     def remove_task(self, task_id, stage):
@@ -303,7 +302,7 @@ class Dataset:
 
         # update dataset timestamps
         pipe.set(self.last_update_key, pack_now())
-        
+
         pipe.execute()
 
         if self.is_done():
@@ -364,29 +363,6 @@ class Dataset:
             tracked = False
 
         return tracked
-
-    def flush_status(self, pipe):
-        """Flush status data such as timestamps and task counts"""
-        # remove the dataset from active datasets
-        pipe.srem(self.key, self.name)
-
-        # reset finished task count
-        pipe.delete(self.finished_key)
-
-        # reset timestamps
-        pipe.delete(self.start_key)
-        pipe.delete(self.last_update_key)
-
-        # delete information about running stages
-        for stage in self.conn.smembers(self.active_stages_key):
-            stage_key = self.get_stage_key(stage)
-            pipe.delete(stage_key)
-            pipe.delete(make_key(stage_key, "pending"))
-            pipe.delete(make_key(stage_key, "running"))
-            pipe.delete(make_key(stage_key, "finished"))
-
-        # delete stages key
-        pipe.delete(self.active_stages_key)
 
     @classmethod
     def is_low_prio(cls, conn, collection_id):

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -211,27 +211,6 @@ class Dataset:
         pipe.set(self.last_update_key, pack_now())
         pipe.execute()
 
-    def remove_task(self, task_id, stage):
-        """Remove a task that's not going to be executed"""
-        log.info(f"Removing task: {task_id}")
-        pipe = self.conn.pipeline()
-        pipe.srem(self.pending_key, task_id)
-
-        stage_key = self.get_stage_key(stage)
-        pipe.srem(stage_key, task_id)
-        pipe.srem(make_key(stage_key, "pending"), task_id)
-
-        pipe.delete(make_key(PREFIX, "qdj", self.name, "taskretry", task_id))
-
-        pipe.set(self.last_update_key, pack_now())
-        pipe.execute()
-
-        status = self.get_status()
-        if status["running"] == 0 and status["pending"] == 0:
-            pipe = self.conn.pipeline()
-            self.flush_status(pipe)
-            pipe.execute()
-
     def checkout_task(self, task_id, stage):
         """Update state when a task is checked out for execution"""
         log.info(f"Checking out task: {task_id}")

--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,7 @@ setup(
             "pytest >= 3.6",
             "coverage",
             "pytest-cov",
+            "time-machine>=2.14.1, <3.0.0",
         ],
     },
     test_suite="tests",

--- a/tests/test_taskqueue.py
+++ b/tests/test_taskqueue.py
@@ -121,9 +121,8 @@ class TaskQueueTest(TestCase):
         assert status["finished"] == 0, status
         assert status["pending"] == 0, status
         assert status["running"] == 0, status
-        started = unpack_datetime(status["start_time"])
-        last_updated = unpack_datetime(status["last_update"])
-        assert started < last_updated
+        assert status["start_time"] is None
+        assert status["last_update"] is None
 
     @patch("servicelayer.taskqueue.Dataset.should_execute")
     def test_task_that_shouldnt_execute(self, mock_should_execute):


### PR DESCRIPTION
I noticed the same issue reported in https://github.com/alephdata/aleph/issues/3787 when working on https://github.com/alephdata/aleph/pull/3788. The current implementation updates the start time whenever a new task is added or checked out, no matter whether the dataset is active or not.

This PR changes the implementation of the dataset status data stored in Redis as follows:

* The implementation `last_update` remains unchanged.
* `start_time` is set to the current time only if it isn’t set yet, i.e. if the task being added is the first task added to a dataset that was inactive before.
* I’ve removed `end_time` (see fd29298 for reasoning), but I’m happy to add it back if that is preferred.
* Once a dataset is done (i.e. there are no more running/pending tasks), all status data is removed from Redis. Previously, some data was reset (e.g. the number of finished tasks) and some other data was retained (e.g. the start time).
* I’ve added a bunch of tests for the dataset status data stored in Redis. I added the `time-machine` package as a dev dependency for this purpose. In my experience, manually mocking dates/times in tests is quite brittle, and I’ve successfully used this package in multiple projects (including in [this Aleph PR](https://github.com/alephdata/aleph/pull/3094)).

Just a note for future reference, as we discussed this but it isn’t documented anywhere: Parts of the status tracking in Redis is probably prone to race conditions when multiple workers are running. This PR doesn't change that. In case this is an issue in practice, we might want to try to replace logic with operations that can be executed atomically.