### PR TITLE
Limit worker queue size

### DIFF
--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -458,9 +458,11 @@ class Worker(ABC):
         self.prefetch_count_mapping = prefetch_count_mapping
 
         # Limit the local queue size to the maximum prefetch count size
-        max_queue_length = max([self.prefetch_count_mapping[q] for q in self.queues])
+        max_queue_length = max(
+            [self.prefetch_count_mapping[q] for q in self.queues], default=1
+        )
         self.local_queue = Queue(maxsize=max_queue_length)
-        log.info(f"local_queue initialized with max_size={max_queue_length}")
+        log.info(f"local_queue initialized with maxsize={max_queue_length}")
 
     def run_prometheus_server(self):
         if not settings.PROMETHEUS_ENABLED:

--- a/servicelayer/taskqueue.py
+++ b/servicelayer/taskqueue.py
@@ -9,7 +9,7 @@ import logging
 import sys
 from abc import ABC, abstractmethod
 import functools
-from queue import SimpleQueue, Empty, Full
+from queue import Queue, Empty, Full
 import platform
 from collections import defaultdict
 from threading import Thread
@@ -457,6 +457,11 @@ class Worker(ABC):
         self.version = version
         self.prefetch_count_mapping = prefetch_count_mapping
 
+        # Limit the local queue size to the maximum prefetch count size
+        max_queue_length = max([self.prefetch_count_mapping[q] for q in self.queues])
+        self.local_queue = Queue(maxsize=max_queue_length)
+        log.info(f"local_queue initialized with max_size={max_queue_length}")
+
     def run_prometheus_server(self):
         if not settings.PROMETHEUS_ENABLED:
             return
@@ -704,11 +709,6 @@ class Worker(ABC):
                 channel, queue, prefetch_count=self.prefetch_count_mapping[queue]
             )
             channel.basic_consume(queue=queue, on_message_callback=on_message_callback)
-
-        # Limit the local queue size to the maximum prefetch count size
-        max_queue_length = max([self.prefetch_count_mapping(q) for q in self.queues])
-        self.local_queue = SimpleQueue(max_size=max_queue_length)
-        log.info(f"local_queue initialized with max_size={max_queue_length}")
 
         channel.start_consuming()
 


### PR DESCRIPTION
This fixes an issue where long-running tasks could get assigned to a worker which would start the work but then also accept other tasks before the work is done. 

Most of the time it makes sense for a worker to accept one message at a time, except for deployments with specialized workers, like an index-worker which might have a higher prefetch count. This is why we set the local_queue maxsize to the maximum of the prefetch count for that given worker.